### PR TITLE
Add further log configuration

### DIFF
--- a/manage_breast_screening/config/.env.tpl
+++ b/manage_breast_screening/config/.env.tpl
@@ -1,3 +1,4 @@
 SECRET_KEY="django-insecure-rqrslm6t05zphv(-j(k4*ri$ua8u1d8hg827w!m21+viul_hw&"
 DEBUG=True
 ALLOWED_HOSTS="localhost,127.0.0.1"
+GUNICORN_CMD_ARGS="--log-level DEBUG"

--- a/manage_breast_screening/config/settings.py
+++ b/manage_breast_screening/config/settings.py
@@ -167,9 +167,10 @@ LOGGING = {
     "disable_existing_loggers": False,  # retain the default loggers
     "formatters": {
         "verbose": {
-            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
-            "style": "{",
-        },
+            "format": "%(asctime)s [%(process)d] [%(levelname)s] [%(module)s] %(message)s",
+            "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
+            "class": "logging.Formatter",
+        }
     },
     "handlers": {
         "console": {
@@ -185,6 +186,21 @@ LOGGING = {
     "loggers": {
         "django": {
             "level": "DEBUG",
+            "handlers": ["console"],
+            "propagate": False,
+        },
+        "django.db.backends": {
+            "level": "DEBUG" if DEBUG else "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+        },
+        "django.server": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+        },
+        "django.utils.autoreload": {
+            "level": "INFO",
             "handlers": ["console"],
             "propagate": False,
         },


### PR DESCRIPTION
## Description

Make the logging more verbose. This PR is stacked on top of https://github.com/NHSDigital/manage-breast-screening-django-spike/pull/3

## Context

While debugging deployment to Azure we didn't get any logging out of Django, so I wanted to check it's actually configured correctly. It is - but the formatting is inconsistent with Gunicorn, and we could do with DEBUG
logging as well at least in the short term.

We are expecting to run gunicorn with log level DEBUG also, so that it logs the requests being made.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
